### PR TITLE
feat: :sparkles: Add falling to tetris block

### DIFF
--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -8,9 +8,13 @@ const INITIAL_POSITION: Vec2 = Vec2::new(
     -1.0 * GRID_SIZE - GRID_SIZE / 2.0,
     10.0 * GRID_SIZE - GRID_SIZE / 2.0,
 );
- 
+const FPS: f32 = 1.0;
+
+#[derive(Component, Deref, DerefMut)]
+struct FallingTimer(Timer);
+
 #[derive(Component)]
-#[require(Sprite, Transform)]
+#[require(Sprite, Transform, FallingTimer)]
 struct Block;
 
 #[allow(dead_code)]
@@ -22,6 +26,12 @@ enum BlockType {
     TypeS,
     TypeT,
     TypeZ,
+}
+
+impl Default for FallingTimer {
+    fn default() -> Self {
+        Self(Timer::from_seconds(FPS, TimerMode::Repeating))
+    }
 }
 
 impl BlockType {
@@ -68,7 +78,7 @@ impl BlockType {
 }
 
 impl Block {
-    fn new(i: usize, block: BlockType) -> (Self, Sprite, Transform) {
+    fn new(i: usize, block: BlockType) -> (Self, Sprite, Transform, FallingTimer) {
         (
             Self,
             Sprite::from_color(block.color(), Vec2::ONE),
@@ -77,6 +87,7 @@ impl Block {
                 scale: SIZE.extend(1.0),
                 ..Default::default()
             },
+            FallingTimer::default(),
         )
     }
 }
@@ -95,12 +106,26 @@ fn setup(
     }
 }
 
+fn falling(
+    mut query: Query<(&mut FallingTimer, &mut Transform), With<Block>>,
+    time: Res<Time>,
+) {
+    for (mut timer, mut transform) in &mut query {
+        timer.tick(time.delta());
+        if !timer.just_finished() { continue }
+        timer.reset();
+        // debug!("movement");
+        transform.translation.y -= GRID_SIZE;
+    }
+}
+
 pub struct BlocksPlugin;
 
 impl Plugin for BlocksPlugin {
     fn build(&self, app: &mut App) {
         app
             .add_systems(Startup, setup)
+            .add_systems(Update, falling)
         ;
     }
 }


### PR DESCRIPTION
# Issue:
- #10

## Changes
テトリスブロックに落下処理を追加しました。
1秒間に1マスずつ下に移動していきます。
まだ壁判定を実装していないのでブロックは壁をすり抜けて落下しますが問題ないです