### PR TITLE
ブロックに当たり判定を追加

### DIFF
--- a/src/block/collision.rs
+++ b/src/block/collision.rs
@@ -1,13 +1,15 @@
 use bevy::prelude::*;
 
+use crate::GRID_SIZE;
 use crate::player::{
     BlockMoveEvent,
     BlockDirection,
 };
-use crate::block::spawn::Block;
 use super::{
+    SpawnEvent,
     PlayerBlock,
 };
+use super::spawn::Block;
 
 #[derive(Event, Default)]
 pub struct CollisionEvent;
@@ -29,9 +31,9 @@ pub fn check_for_collision(
                 // trace!("block_pos: {}", block_pos);
                 if player_pos == block_pos {
                     match direction {
-                        BlockDirection::Left   => { debug!("collision left") }
-                        BlockDirection::Right  => { debug!("collision right") }
-                        BlockDirection::Bottom => { debug!("collision bottom") }
+                        BlockDirection::Left   => {}
+                        BlockDirection::Right  => {}
+                        BlockDirection::Bottom => {}
                     }
                     // trace!("send collision event");
                     write_events.send_default();
@@ -42,6 +44,22 @@ pub fn check_for_collision(
     }
 }
 
+pub fn collision(
+    mut read_events: EventReader<CollisionEvent>,
+    mut write_events: EventWriter<SpawnEvent>,
+    mut commands: Commands,
+    mut query: Query<(Entity, &mut Transform), With<PlayerBlock>>,
+) {
+    if read_events.is_empty() { return }
+    read_events.clear();
+    // trace!("move block");
+    for (entity, mut transform) in &mut query {
+        transform.translation.y += GRID_SIZE;
+        commands.entity(entity).remove::<PlayerBlock>();
+    }
+    write_events.send_default();
+}
+
 pub struct CollisionPlugin;
 
 impl Plugin for CollisionPlugin {
@@ -50,6 +68,7 @@ impl Plugin for CollisionPlugin {
             .add_event::<CollisionEvent>()
             // .add_systems(Update, ( // move block/movement.rs
             //     // check_for_collision,
+            //     // collision,
             // ))
         ;
     }

--- a/src/block/collision.rs
+++ b/src/block/collision.rs
@@ -1,10 +1,56 @@
 use bevy::prelude::*;
 
+use crate::player::{
+    BlockMoveEvent,
+    BlockDirection,
+};
+use crate::block::spawn::Block;
+use super::{
+    PlayerBlock,
+};
+
+#[derive(Event, Default)]
+pub struct CollisionEvent;
+
+pub fn check_for_collision(
+    mut read_events: EventReader<BlockMoveEvent>,
+    mut write_events: EventWriter<CollisionEvent>,
+    player_query: Query<&Transform, With<PlayerBlock>>,
+    block_query: Query<&Transform, (With<Block>, Without<PlayerBlock>)>,
+) {
+    for event in read_events.read() {
+        let direction = event.0;
+        // debug!("check_for_collision");
+        for player_transform in &player_query {
+            let player_pos = player_transform.translation;
+            // trace!("player_pos: {}", player_pos);
+            for block_transform in &block_query {
+                let block_pos = block_transform.translation;
+                // trace!("block_pos: {}", block_pos);
+                if player_pos == block_pos {
+                    match direction {
+                        BlockDirection::Left   => { debug!("collision left") }
+                        BlockDirection::Right  => { debug!("collision right") }
+                        BlockDirection::Bottom => { debug!("collision bottom") }
+                    }
+                    // trace!("send collision event");
+                    write_events.send_default();
+                    return;
+                }
+            }
+        }
+    }
+}
+
 pub struct CollisionPlugin;
 
 impl Plugin for CollisionPlugin {
     fn build(&self, app: &mut App) {
         app
+            .add_event::<CollisionEvent>()
+            // .add_systems(Update, ( // move block/movement.rs
+            //     // check_for_collision,
+            // ))
         ;
     }
 }

--- a/src/block/collision.rs
+++ b/src/block/collision.rs
@@ -1,0 +1,10 @@
+use bevy::prelude::*;
+
+pub struct CollisionPlugin;
+
+impl Plugin for CollisionPlugin {
+    fn build(&self, app: &mut App) {
+        app
+        ;
+    }
+}

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -2,6 +2,7 @@ use bevy::prelude::*;
 
 use crate::wall::ReachBottomEvent;
 
+mod collision;
 mod movement;
 mod spawn;
 
@@ -31,6 +32,7 @@ impl Plugin for BlockPlugin {
     fn build(&self, app: &mut App) {
         app
             .add_event::<SpawnEvent>()
+            .add_plugins(collision::CollisionPlugin)
             .add_plugins(movement::MovementPlugin)
             .add_plugins(spawn::SpawnPlugin)
             .add_systems(Update, (

--- a/src/block/movement.rs
+++ b/src/block/movement.rs
@@ -57,6 +57,7 @@ impl Plugin for MovementPlugin {
                 falling,
                 movement,
                 crate::wall::check_for_wall,
+                crate::block::collision::check_for_collision,
             ).chain())
         ;
     }

--- a/src/block/movement.rs
+++ b/src/block/movement.rs
@@ -54,6 +54,7 @@ impl Plugin for MovementPlugin {
         app
             .insert_resource(FallingTimer::default())
             .add_systems(Update, (
+                crate::player::block_movement,
                 falling,
                 movement,
                 crate::wall::check_for_wall,

--- a/src/block/movement.rs
+++ b/src/block/movement.rs
@@ -27,8 +27,9 @@ fn movement(
         // trace!("direction: {:?}", direction);
         for mut transform in &mut query {
             match direction {
-                BlockDirection::Left  => transform.translation.x -= GRID_SIZE,
-                BlockDirection::Right => transform.translation.x += GRID_SIZE,
+                BlockDirection::Left   => transform.translation.x -= GRID_SIZE,
+                BlockDirection::Right  => transform.translation.x += GRID_SIZE,
+                BlockDirection::Bottom => transform.translation.y -= GRID_SIZE,
             }
         }
     }
@@ -36,16 +37,14 @@ fn movement(
 
 fn falling(
     mut timer: ResMut<FallingTimer>,
-    mut query: Query<&mut Transform, With<PlayerBlock>>,
+    mut events: EventWriter<BlockMoveEvent>,
     time: Res<Time>,
 ) {
     timer.tick(time.delta());
     if !timer.just_finished() { return }
     timer.reset();
     // debug!("falling block");
-    for mut transform in &mut query {
-        transform.translation.y -= GRID_SIZE;
-    }
+    events.send(BlockMoveEvent(BlockDirection::Bottom));
 }
 
 pub struct MovementPlugin;
@@ -55,8 +54,8 @@ impl Plugin for MovementPlugin {
         app
             .insert_resource(FallingTimer::default())
             .add_systems(Update, (
-                movement,
                 falling,
+                movement,
                 crate::wall::check_for_wall,
             ).chain())
         ;

--- a/src/block/movement.rs
+++ b/src/block/movement.rs
@@ -58,6 +58,7 @@ impl Plugin for MovementPlugin {
                 movement,
                 crate::wall::check_for_wall,
                 crate::block::collision::check_for_collision,
+                crate::block::collision::collision,
             ).chain())
         ;
     }

--- a/src/block/spawn.rs
+++ b/src/block/spawn.rs
@@ -105,11 +105,12 @@ fn spawn(
 ) {
     if events.is_empty() { return }
     events.clear();
+    // debug!("spawn");
     for i in 1..BLOCK_COUNT + 1 {
-        commands.spawn(Block::new(i, BlockType::TypeI));
+        // commands.spawn(Block::new(i, BlockType::TypeI));
         // commands.spawn(Block::new(i, BlockType::TypeJ));
         // commands.spawn(Block::new(i, BlockType::TypeL));
-        // commands.spawn(Block::new(i, BlockType::TypeO));
+        commands.spawn(Block::new(i, BlockType::TypeO));
         // commands.spawn(Block::new(i, BlockType::TypeS));
         // commands.spawn(Block::new(i, BlockType::TypeT));
         // commands.spawn(Block::new(i, BlockType::TypeZ));

--- a/src/block/spawn.rs
+++ b/src/block/spawn.rs
@@ -15,7 +15,7 @@ const INITIAL_POSITION: Vec2 = Vec2::new(
 
 #[derive(Component)]
 #[require(Sprite, Transform, PlayerBlock)]
-struct Block;
+pub struct Block;
 
 #[allow(dead_code)]
 enum BlockType {

--- a/src/player.rs
+++ b/src/player.rs
@@ -8,14 +8,14 @@ const KEY_BLOCK_RIGHT_2: KeyCode = KeyCode::KeyD;
 #[derive(Event)]
 pub struct BlockMoveEvent(pub BlockDirection);
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum BlockDirection {
     Left,
     Right,
     Bottom,
 }
 
-fn block_movement(
+pub fn block_movement(
     mut events: EventWriter<BlockMoveEvent>,
     keyboard_input: Res<ButtonInput<KeyCode>>,
 ) {
@@ -39,7 +39,7 @@ impl Plugin for PlayerPlugin {
     fn build(&self, app: &mut App) {
         app
             .add_event::<BlockMoveEvent>()
-            .add_systems(Update, block_movement)
+            // .add_systems(Update, block_movement)
         ;
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -12,6 +12,7 @@ pub struct BlockMoveEvent(pub BlockDirection);
 pub enum BlockDirection {
     Left,
     Right,
+    Bottom,
 }
 
 fn block_movement(

--- a/src/wall.rs
+++ b/src/wall.rs
@@ -123,7 +123,7 @@ impl Plugin for WallPlugin {
         app
             .add_event::<ReachBottomEvent>()
             .add_systems(Startup, setup)
-            // .add_systems(Update, check_for_wall) // move block.rs
+            // .add_systems(Update, check_for_wall) // move block/movement.rs
         ;
     }
 }


### PR DESCRIPTION
# Issue
- #20

## Changes
ブロック同士に当たり判定を追加しました。
ブロックが当たり判定を検知すると、その場からブロックは動かなくなり新しいブロックが生成されます。

## Code
- `src/block/collision.rs`の追加
- `collision.rs`に`check_for_collision`というブロック同士の当たり判定を検知するシステムを追加
- `collision.rs`に`collision`という当たり判定に応じたブロックの移動を行うシステムを追加
- `BlockDirection`に`Bottom`属性を追加し、それに関わる`falling`システムを修正