### PR TITLE
feat: :recycle: refact `crate::wall::check_for_wall`

### DIFF
--- a/src/block/movement.rs
+++ b/src/block/movement.rs
@@ -5,6 +5,7 @@ use crate::player::{
     BlockDirection,
     BlockMoveEvent,
 };
+use crate::wall::WallCollisionEvent;
 use super::PlayerBlock;
 
 const FPS: f32 = 0.2;
@@ -31,10 +32,12 @@ pub fn falling(
 }
 
 pub fn movement(
-    mut events: EventReader<BlockMoveEvent>,
+    mut read_events1: EventReader<BlockMoveEvent>,
     mut query: Query<&mut Transform, With<PlayerBlock>>,
+    read_events2: EventReader<WallCollisionEvent>,
 ) {
-    for event in events.read() {
+    if !read_events2.is_empty()  { return }
+    for event in read_events1.read() {
         let direction = event.0;
         // trace!("direction: {:?}", direction);
         for mut transform in &mut query {

--- a/src/player.rs
+++ b/src/player.rs
@@ -42,8 +42,8 @@ impl Plugin for PlayerPlugin {
             .add_systems(Update, (
                 block_movement,
                 crate::block::movement::falling,
-                crate::block::movement::movement,
                 crate::wall::check_for_wall,
+                crate::block::movement::movement,
                 crate::block::collision::check_for_collision,
                 crate::block::collision::collision,
             ).chain())


### PR DESCRIPTION
# Issue:
- #28

## Changes

変更前の`check_for_wall`は、ブロック移動後にブロックが壁からはみ出していた場合、ブロックを動かして壁からはみ出さないようにする処理でした。

変更後は、ブロック移動前にブロックが壁からはみ出そうとした場合、ブロックの移動処理を行わないようにしました

## Code Changes
- `player.rs`にて`check_for_wall`の処理する順番を変更
- `wall.rs`に`WallCollisionEvent`を追加
- `check_for_wall`に`WallCollisionEvent`を追加して、当たり判定を`crate::block::movement::movement`に知らせる機能を実装
- `check_for_wall`のブロック移動処理を削除