### PR TITLE
fix: :recycle: crate::block:: collision ::check_for_collision

### DIFF
--- a/src/block/collision.rs
+++ b/src/block/collision.rs
@@ -5,18 +5,17 @@ use crate::player::{
     BlockMoveEvent,
     BlockDirection,
 };
-use super::{
-    SpawnEvent,
-    PlayerBlock,
-};
+use super::PlayerBlock;
 use super::spawn::Block;
+use crate::wall::ReachBottomEvent;
 
-#[derive(Event)]
-pub struct CollisionEvent(BlockDirection);
+#[derive(Event, Default)]
+pub struct BlockCollisionEvent;
 
 pub fn check_for_collision(
     mut read_events: EventReader<BlockMoveEvent>,
-    mut write_events: EventWriter<CollisionEvent>,
+    mut write_events1: EventWriter<BlockCollisionEvent>,
+    mut write_events2: EventWriter<ReachBottomEvent>,
     player_query: Query<&Transform, With<PlayerBlock>>,
     block_query: Query<&Transform, (With<Block>, Without<PlayerBlock>)>,
 ) {
@@ -24,14 +23,21 @@ pub fn check_for_collision(
         let direction = event.0;
         // debug!("check_for_collision");
         for player_transform in &player_query {
-            let player_pos = player_transform.translation;
+            let mut player_pos = player_transform.translation;
+            match direction {
+                BlockDirection::Left   => player_pos.x -= GRID_SIZE,
+                BlockDirection::Right  => player_pos.x += GRID_SIZE,
+                BlockDirection::Bottom => player_pos.y -= GRID_SIZE,
+            }
             // trace!("player_pos: {}", player_pos);
             for block_transform in &block_query {
                 let block_pos = block_transform.translation;
                 // trace!("block_pos: {}", block_pos);
                 if player_pos == block_pos {
-                    // debug!("send collision event");
-                    write_events.send(CollisionEvent(direction));
+                    write_events1.send_default();
+                    if direction == BlockDirection::Bottom {
+                        write_events2.send_default();
+                    }
                     return;
                 }
             }
@@ -72,7 +78,7 @@ pub struct CollisionPlugin;
 impl Plugin for CollisionPlugin {
     fn build(&self, app: &mut App) {
         app
-            .add_event::<CollisionEvent>()
+            .add_event::<BlockCollisionEvent>()
             // .add_systems(Update, check_for_collision)
             // .add_systems(Update, collision)
         ;

--- a/src/block/collision.rs
+++ b/src/block/collision.rs
@@ -45,34 +45,6 @@ pub fn check_for_collision(
     }
 }
 
-pub fn collision(
-    mut read_events: EventReader<CollisionEvent>,
-    mut write_events: EventWriter<SpawnEvent>,
-    mut commands: Commands,
-    mut query: Query<(Entity, &mut Transform), With<PlayerBlock>>,
-) {
-    for event in read_events.read() {
-        let direction = event.0;
-        let mut closure = |direction: BlockDirection, movement: Vec3| {
-            for (entity, mut transform) in &mut query {
-                transform.translation += movement;
-                // trace!("pos: {}", transform.translation);
-                if direction == BlockDirection::Bottom {
-                    commands.entity(entity).remove::<PlayerBlock>();
-                    write_events.send_default();
-                }
-            }
-        };
-        let movement = Vec3::ZERO;
-        // debug!("collision");
-        match direction {
-            BlockDirection::Left   => closure(direction, movement.with_x(GRID_SIZE)),
-            BlockDirection::Right  => closure(direction, movement.with_x(-GRID_SIZE)),
-            BlockDirection::Bottom => closure(direction, movement.with_y(GRID_SIZE)),
-        }
-    }
-}
-
 pub struct CollisionPlugin;
 
 impl Plugin for CollisionPlugin {
@@ -80,7 +52,6 @@ impl Plugin for CollisionPlugin {
         app
             .add_event::<BlockCollisionEvent>()
             // .add_systems(Update, check_for_collision)
-            // .add_systems(Update, collision)
         ;
     }
 }

--- a/src/block/movement.rs
+++ b/src/block/movement.rs
@@ -6,6 +6,7 @@ use crate::player::{
     BlockMoveEvent,
 };
 use super::PlayerBlock;
+use super::collision::BlockCollisionEvent;
 
 const FPS: f32 = 0.2;
 
@@ -31,10 +32,12 @@ pub fn falling(
 }
 
 pub fn movement(
-    mut events: EventReader<BlockMoveEvent>,
+    mut read_events1: EventReader<BlockMoveEvent>,
     mut query: Query<&mut Transform, With<PlayerBlock>>,
+    read_events2: EventReader<BlockCollisionEvent>
 ) {
-    for event in events.read() {
+    if !read_events2.is_empty() { return }
+    for event in read_events1.read() {
         let direction = event.0;
         // trace!("direction: {:?}", direction);
         for mut transform in &mut query {

--- a/src/player.rs
+++ b/src/player.rs
@@ -45,7 +45,6 @@ impl Plugin for PlayerPlugin {
                 crate::block::collision::check_for_collision,
                 crate::block::movement::movement,
                 crate::wall::check_for_wall,
-                crate::block::collision::collision,
             ).chain())
         ;
     }

--- a/src/player.rs
+++ b/src/player.rs
@@ -42,9 +42,9 @@ impl Plugin for PlayerPlugin {
             .add_systems(Update, (
                 block_movement,
                 crate::block::movement::falling,
+                crate::block::collision::check_for_collision,
                 crate::block::movement::movement,
                 crate::wall::check_for_wall,
-                crate::block::collision::check_for_collision,
                 crate::block::collision::collision,
             ).chain())
         ;


### PR DESCRIPTION
# Issue
- #30

## Changes
変更前の`check_for_collision`は、ブロック移動後にブロック同士の衝突判定を検知して、判定があればブロック同士が重ならないようにする処理でした。

変更後は、ブロック移動前にブロック同士の衝突判定を検知して、判定があればブロックの移動処理を行わないようにしました。

## Code Changes
- `player.rs`の`check_for_collision`の処理の順番を変更
- `block/collision.rs`に`BlockCollisionEvent`を追加
- `check_for_collision`に`BlockCollisionEvent`を追加して`crate::block::movement::movement`に判定を知らせる
- `crate::block::collision::collision`の削除