### PR TITLE
feat: :sparkles: Add Gameover

### DIFF
--- a/src/block/collision.rs
+++ b/src/block/collision.rs
@@ -6,21 +6,16 @@ use super::movement::{
     Direction,
     MoveEvent,
 };
-use super::spawn::{
-    SpawnEvent,
-    Block,
-};
+use super::spawn::Block;
+use crate::wall::BottomHitEvent as BlockBottomHitEvent;
 
 #[derive(Event, Default)]
 pub struct CollisionEvent;
 
-#[derive(Event, Default)]
-pub struct BottomHitEvent;
-
 pub fn check_for_collision(
     mut read_events: EventReader<MoveEvent>,
     mut write_events1: EventWriter<CollisionEvent>,
-    mut write_events2: EventWriter<BottomHitEvent>,
+    mut write_events2: EventWriter<BlockBottomHitEvent>,
     player_query: Query<&Transform, With<PlayerBlock>>,
     block_query: Query<&Transform, (With<Block>, Without<PlayerBlock>)>,
 ) {
@@ -50,29 +45,13 @@ pub fn check_for_collision(
     }
 }
 
-fn bottom_hit(
-    mut read_events: EventReader<BottomHitEvent>,
-    mut write_events: EventWriter<SpawnEvent>,
-    mut commands: Commands,
-    query: Query<Entity, With<PlayerBlock>>,
-) {
-    if read_events.is_empty() { return }
-    read_events.clear();
-    // debug!("remove PlayerBlock components");
-    for entity in &query { commands.entity(entity).remove::<PlayerBlock>(); }
-    // debug!("send spawn event");
-    write_events.send_default();
-}
-
 pub struct CollisionPlugin;
 
 impl Plugin for CollisionPlugin {
     fn build(&self, app: &mut App) {
         app
             .add_event::<CollisionEvent>()
-            .add_event::<BottomHitEvent>()
             // .add_systems(Update, check_for_collision)
-            .add_systems(Update, bottom_hit)
         ;
     }
 }

--- a/src/block/movement.rs
+++ b/src/block/movement.rs
@@ -1,6 +1,9 @@
 use bevy::prelude::*;
 
-use crate::GRID_SIZE;
+use crate::{
+    AppState,
+    GRID_SIZE,
+};
 use super::PlayerBlock;
 use super::collision::CollisionEvent as BlockCollisionEvent;
 use crate::wall::CollisionEvent as WallCollisionEvent;
@@ -59,6 +62,13 @@ pub fn movement(
     }
 }
 
+fn reset_timer(
+    mut timer: ResMut<FallingTimer>,
+) {
+    // debug!("reset_timer");
+    timer.reset();
+}
+
 pub struct MovementPlugin;
 
 impl Plugin for MovementPlugin {
@@ -68,6 +78,7 @@ impl Plugin for MovementPlugin {
             .insert_resource(FallingTimer::default())
             // .add_systems(Update, falling)
             // .add_systems(Update, movement)
+            .add_systems(OnExit(AppState::Ingame), reset_timer)
         ;
     }
 }

--- a/src/block/spawn.rs
+++ b/src/block/spawn.rs
@@ -147,6 +147,14 @@ fn check_position(
     }
 }
 
+fn despawn_all(
+    mut commands: Commands,
+    query: Query<Entity, With<Block>>,
+) {
+    // debug!("despawn_all");
+    for entity in &query { commands.entity(entity).despawn() }
+}
+
 pub struct SpawnPlugin;
 
 impl Plugin for SpawnPlugin {
@@ -154,8 +162,11 @@ impl Plugin for SpawnPlugin {
         app
             .add_event::<SpawnEvent>()
             .add_systems(OnEnter(AppState::Ingame), setup)
-            .add_systems(Update, spawn.run_if(in_state(AppState::Ingame)))
-            .add_systems(Update, check_position.run_if(in_state(AppState::Ingame)))
+            .add_systems(Update, (
+                spawn,
+                check_position,
+            ).run_if(in_state(AppState::Ingame)))
+            .add_systems(OnExit(AppState::Ingame), despawn_all)
         ;
     }
 }

--- a/src/block/spawn.rs
+++ b/src/block/spawn.rs
@@ -117,6 +117,33 @@ fn spawn(
     }
 }
 
+fn check_position(
+    mut player_query: Query<&mut Transform, With<PlayerBlock>>,
+    block_query: Query<&Transform, (With<Block>, Without<PlayerBlock>)>,
+) {
+    let mut collision = true;
+    // check PlayerBlock position
+    while collision {
+        collision = false;
+        for player_transform in &player_query {
+            let player_pos = player_transform.translation.truncate();
+            for block_transform in &block_query {
+                let block_pos = block_transform.translation.truncate();
+                if player_pos == block_pos {
+                    collision = true;
+                    break;
+                }
+            }
+        }
+        if collision {
+            // move PlayerBlock position
+            for mut transform in &mut player_query {
+                transform.translation.y += GRID_SIZE;
+            }
+        }
+    }
+}
+
 pub struct SpawnPlugin;
 
 impl Plugin for SpawnPlugin {
@@ -125,6 +152,7 @@ impl Plugin for SpawnPlugin {
             .add_event::<SpawnEvent>()
             .add_systems(Startup, setup)
             .add_systems(Update, spawn)
+            .add_systems(Update, check_position)
         ;
     }
 }

--- a/src/block/spawn.rs
+++ b/src/block/spawn.rs
@@ -1,6 +1,9 @@
 use bevy::prelude::*;
 
-use crate::GRID_SIZE;
+use crate::{
+    GRID_SIZE,
+    AppState,
+};
 use crate::utils::blockdata::*;
 use super::PlayerBlock;
 
@@ -150,9 +153,9 @@ impl Plugin for SpawnPlugin {
     fn build(&self, app: &mut App) {
         app
             .add_event::<SpawnEvent>()
-            .add_systems(Startup, setup)
-            .add_systems(Update, spawn)
-            .add_systems(Update, check_position)
+            .add_systems(OnEnter(AppState::Ingame), setup)
+            .add_systems(Update, spawn.run_if(in_state(AppState::Ingame)))
+            .add_systems(Update, check_position.run_if(in_state(AppState::Ingame)))
         ;
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,12 @@ const WINDOW_SIZE: Vec2 = Vec2::new(640.0, 480.0);
 const BACKGROUND_COLOR: Color = Color::srgb(0.1, 0.1, 0.1);
 const PATH_SOUND_BGM: &str = "bevy-tetris/bgm.ogg";
 
+#[derive(States, Clone, Copy, Eq, PartialEq, Hash, Debug)]
+pub enum AppState {
+    Ingame,
+    Gameover,
+}
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins
@@ -32,6 +38,7 @@ fn main() {
                 ..Default::default()
             })
         )
+        .insert_state(AppState::Ingame)
         .insert_resource(ClearColor(BACKGROUND_COLOR))
         .insert_resource(Time::<Fixed>::from_seconds(1.0 / 60.0))
         .add_systems(Startup, (

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 
+use crate::AppState;
 use crate::block::movement::{
     Direction as BlockDirection,
     MoveEvent as BlockMoveEvent,
@@ -39,7 +40,7 @@ impl Plugin for PlayerPlugin {
                 crate::wall::check_for_wall,
                 crate::block::collision::check_for_collision,
                 crate::block::movement::movement,
-            ).chain())
+            ).chain().run_if(in_state(AppState::Ingame)))
         ;
     }
 }

--- a/src/wall.rs
+++ b/src/wall.rs
@@ -155,10 +155,20 @@ fn bottom_hit(
 
 fn top_hit(
     mut read_events: EventReader<TopHitEvent>,
+    mut next_state: ResMut<NextState<AppState>>,
 ) {
     if read_events.is_empty() { return }
     read_events.clear();
-    debug!("top_hit");
+    // trace!("AppState::Ingame -> Gameover");
+    next_state.set(AppState::Gameover);
+}
+
+fn despawn_all(
+    mut commands: Commands,
+    query: Query<Entity, With<Wall>>,
+) {
+    // debug!("despawn_all");
+    for entity in &query { commands.entity(entity).despawn() }
 }
 
 pub struct WallPlugin;
@@ -171,8 +181,11 @@ impl Plugin for WallPlugin {
             .add_event::<TopHitEvent>()
             .add_systems(OnEnter(AppState::Ingame), setup)
             // .add_systems(Update, check_for_wall)
-            .add_systems(Update, bottom_hit.run_if(in_state(AppState::Ingame)))
-            .add_systems(Update, top_hit.run_if(in_state(AppState::Ingame)))
+            .add_systems(Update, (
+                bottom_hit,
+                top_hit,
+            ).run_if(in_state(AppState::Ingame)))
+            .add_systems(OnExit(AppState::Ingame), despawn_all)
         ;
     }
 }

--- a/src/wall.rs
+++ b/src/wall.rs
@@ -2,11 +2,11 @@ use bevy::prelude::*;
 
 use crate::GRID_SIZE;
 use crate::block::PlayerBlock;
-use crate::block::collision::BottomHitEvent as BlockBottomHitEvent;
 use crate::block::movement::{
     Direction as BlockDirection,
     MoveEvent as BlockMoveEvent,
 };
+use crate::block::spawn::SpawnEvent;
 
 const WALL_THICKNESS: f32 = 1.0;
 const LEFT_WALL: f32 = -5.0 * GRID_SIZE;
@@ -17,6 +17,12 @@ const WALL_COLOR: Color = Color::srgb(0.9, 0.9, 0.9);
 
 #[derive(Event, Default)]
 pub struct CollisionEvent;
+
+#[derive(Event, Default)]
+pub struct BottomHitEvent;
+
+#[derive(Event, Default)]
+pub struct TopHitEvent;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum WallLocation {
@@ -85,7 +91,8 @@ fn setup(
 pub fn check_for_wall(
     mut read_events: EventReader<BlockMoveEvent>,
     mut write_events1: EventWriter<CollisionEvent>,
-    mut write_events2: EventWriter<BlockBottomHitEvent>,
+    mut write_events2: EventWriter<BottomHitEvent>,
+    mut write_events3: EventWriter<TopHitEvent>,
     player_query: Query<&Transform, (With<PlayerBlock>, Without<Wall>)>,
     wall_query: Query<(&Wall, &Transform), (With<Wall>, Without<PlayerBlock>)>,
 ) {
@@ -96,6 +103,7 @@ pub fn check_for_wall(
             // trace!("location: {:?}", location);
             write_events1.send_default();
             if location == WallLocation::Bottom { write_events2.send_default(); }
+            if location == WallLocation::Top    { write_events3.send_default(); }
         };
         // check collision wall
         for player_transform in &player_query {
@@ -128,14 +136,40 @@ pub fn check_for_wall(
     }
 }
 
+fn bottom_hit(
+    mut read_events: EventReader<BottomHitEvent>,
+    mut write_events: EventWriter<SpawnEvent>,
+    mut commands: Commands,
+    query: Query<Entity, With<PlayerBlock>>,
+) {
+    if read_events.is_empty() { return }
+    read_events.clear();
+    // debug!("remove PlayerBlock components");
+    for entity in &query { commands.entity(entity).remove::<PlayerBlock>(); }
+    // debug!("send spawn event");
+    write_events.send_default();
+}
+
+fn top_hit(
+    mut read_events: EventReader<TopHitEvent>,
+) {
+    if read_events.is_empty() { return }
+    read_events.clear();
+    debug!("top_hit");
+}
+
 pub struct WallPlugin;
 
 impl Plugin for WallPlugin {
     fn build(&self, app: &mut App) {
         app
             .add_event::<CollisionEvent>()
+            .add_event::<BottomHitEvent>()
+            .add_event::<TopHitEvent>()
             .add_systems(Startup, setup)
             // .add_systems(Update, check_for_wall)
+            .add_systems(Update, bottom_hit)
+            .add_systems(Update, top_hit)
         ;
     }
 }

--- a/src/wall.rs
+++ b/src/wall.rs
@@ -1,6 +1,9 @@
 use bevy::prelude::*;
 
-use crate::GRID_SIZE;
+use crate::{
+    GRID_SIZE,
+    AppState,
+};
 use crate::block::PlayerBlock;
 use crate::block::movement::{
     Direction as BlockDirection,
@@ -166,10 +169,10 @@ impl Plugin for WallPlugin {
             .add_event::<CollisionEvent>()
             .add_event::<BottomHitEvent>()
             .add_event::<TopHitEvent>()
-            .add_systems(Startup, setup)
+            .add_systems(OnEnter(AppState::Ingame), setup)
             // .add_systems(Update, check_for_wall)
-            .add_systems(Update, bottom_hit)
-            .add_systems(Update, top_hit)
+            .add_systems(Update, bottom_hit.run_if(in_state(AppState::Ingame)))
+            .add_systems(Update, top_hit.run_if(in_state(AppState::Ingame)))
         ;
     }
 }


### PR DESCRIPTION
# Issue:
- #26

## Changes
ゲームオーバー機能を追加しました。
ブロックが壁の頂上を突き抜けるとゲームオーバーとなり、全てのコンポーネントが削除されます。
## Code Changes
- `crate::wall::top_hit`システムを追加し、ゲームオーバーかどうか判断する
- `crate::block::spawn::check_position`システムを追加し、ブロック生成時のポジションにブロックがあった場合、生成ポジションを上に移動させる。
- `main.rs`に`AppState`というゲームの状態を表す列挙型を定義
- ゲームオーバー時にコンポーネントを削除する、`despawn_all`システムと、タイマーをリセットする`reset_timer`システムを追加