### PR TITLE
feat: :sparkles: Add rand to BlockType

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,6 +1073,7 @@ name = "bevy_tetris"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "rand",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 bevy = "0.15.1"
+rand = "0.8.5"

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -45,6 +45,7 @@ pub struct SpawnEvent;
 pub struct CurrentBlock {
     id: usize,
     block: BlockType,
+    init_pos: Vec2,
 }
 
 #[derive(Component, Default)]
@@ -88,6 +89,7 @@ impl CurrentBlock {
         CurrentBlock {
             id: 0,
             block: Self::random_block(),
+            init_pos: BLOCK_POSITION,
         }
     }
 

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -1,4 +1,9 @@
 use bevy::prelude::*;
+use rand::{
+    distributions::Standard,
+    prelude::Distribution,
+    Rng,
+};
 
 use crate::{
     GRID_SIZE,
@@ -61,15 +66,37 @@ enum BlockType {
     TypeZ,
 }
 
+impl Distribution<BlockType> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> BlockType {
+        let index: u8 = rng.gen_range(0..7);
+
+        match index {
+            0 => BlockType::TypeI,
+            1 => BlockType::TypeJ,
+            2 => BlockType::TypeL,
+            3 => BlockType::TypeO,
+            4 => BlockType::TypeS,
+            5 => BlockType::TypeT,
+            6 => BlockType::TypeZ,
+            _ => unreachable!(),
+        }
+    }
+}
+
 impl CurrentBlock {
     fn new() -> Self {
         CurrentBlock {
             id: 0,
-            block: BlockType::TypeO,
+            block: Self::random_block(),
         }
     }
 
     pub fn reset() -> Self { Self::new() }
+
+    fn random_block() -> BlockType {
+        let mut rng = rand::thread_rng();
+        rng.gen()
+    }
 }
 
 fn reset_current_block(

--- a/src/block/movement.rs
+++ b/src/block/movement.rs
@@ -6,10 +6,11 @@ use crate::{
 };
 use super::{
     BLOCK_SPEED,
-    PlayerBlock,
     CollisionEvent as BlockCollisionEvent,
     Direction,
     MoveEvent,
+    CurrentBlock,
+    PlayerBlock,
 };
 use crate::wall::CollisionEvent as WallCollisionEvent;
 
@@ -37,6 +38,7 @@ pub fn falling(
 pub fn movement(
     mut read_events1: EventReader<MoveEvent>,
     mut query: Query<&mut Transform, With<PlayerBlock>>,
+    mut current_block: ResMut<CurrentBlock>,
     read_events2: EventReader<WallCollisionEvent>,
     read_events3: EventReader<BlockCollisionEvent>
 ) {
@@ -52,6 +54,12 @@ pub fn movement(
                 Direction::Bottom => transform.translation.y -= GRID_SIZE,
             }
         }
+        match direction {
+            Direction::Left   => current_block.init_pos.x -= GRID_SIZE,
+            Direction::Right  => current_block.init_pos.x += GRID_SIZE,
+            Direction::Bottom => current_block.init_pos.y -= GRID_SIZE,
+        }
+        // trace!("current_block.init_pos: {}", current_block.init_pos);
     }
 }
 

--- a/src/block/spawn.rs
+++ b/src/block/spawn.rs
@@ -114,6 +114,7 @@ fn spawn(
 
 fn check_position(
     mut player_query: Query<&mut Transform, With<PlayerBlock>>,
+    mut current_block: ResMut<CurrentBlock>,
     block_query: Query<&Transform, (With<Block>, Without<PlayerBlock>)>,
 ) {
     let mut collision = true;
@@ -135,6 +136,7 @@ fn check_position(
             for mut transform in &mut player_query {
                 transform.translation.y += GRID_SIZE;
             }
+            current_block.init_pos.y += GRID_SIZE;
         }
     }
 }


### PR DESCRIPTION
# Issue
- #36

## Changes
ブロック生成時にブロックの種類をランダムになるようにしました。
これにより次に生成されるブロックの種類が何になるのかわからなくなります。

### Code changes
- `rand`クレートを追加
- `BlockType`に乱数を追加
- `CurrentBlock`に`random_block`を追加