### PR TITLE
feat: :sparkles: Add block rotation process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,6 +1073,7 @@ name = "bevy_tetris"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "rand",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 bevy = "0.15.1"
+rand = "0.8.5"

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -48,11 +48,11 @@ pub struct CurrentBlock {
     init_pos: Vec2,
 }
 
-#[derive(Component, Default)]
-pub struct PlayerBlock;
+#[derive(Component)]
+pub struct PlayerBlock(pub usize);
 
 #[derive(Component)]
-#[require(Sprite, Transform, PlayerBlock)]
+#[require(Sprite, Transform)]
 pub struct Block;
 
 #[allow(dead_code)]

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -4,7 +4,7 @@ use crate::GRID_SIZE;
 
 pub mod collision;
 pub mod movement;
-mod rotation;
+pub mod rotation;
 mod spawn;
 
 const BLOCK_SPEED: f32 = 0.2;
@@ -25,7 +25,7 @@ pub enum Direction {
 }
 
 #[derive(Event, Default)]
-struct RotationEvent;
+pub struct RotationEvent;
 
 #[derive(Event, Default)]
 pub struct CollisionEvent;
@@ -62,7 +62,7 @@ impl Plugin for BlockPlugin {
             .add_event::<SpawnEvent>()
             // .add_plugins(collision::CollisionPlugin)
             .add_plugins(movement::MovementPlugin)
-            .add_plugins(rotation::RotationPlugin)
+            // .add_plugins(rotation::RotationPlugin)
             .add_plugins(spawn::SpawnPlugin)
         ;
     }

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -4,7 +4,8 @@ use crate::GRID_SIZE;
 
 pub mod collision;
 pub mod movement;
-pub mod spawn;
+mod rotation;
+mod spawn;
 
 const BLOCK_SPEED: f32 = 0.2;
 const BLOCK_SIZE: Vec2 = Vec2::splat(GRID_SIZE - 2.0);
@@ -22,6 +23,9 @@ pub enum Direction {
     Right,
     Bottom,
 }
+
+#[derive(Event, Default)]
+struct RotationEvent;
 
 #[derive(Event, Default)]
 pub struct CollisionEvent;
@@ -53,10 +57,12 @@ impl Plugin for BlockPlugin {
     fn build(&self, app: &mut App) {
         app
             .add_event::<MoveEvent>()
+            .add_event::<RotationEvent>()
             .add_event::<CollisionEvent>()
             .add_event::<SpawnEvent>()
             // .add_plugins(collision::CollisionPlugin)
             .add_plugins(movement::MovementPlugin)
+            .add_plugins(rotation::RotationPlugin)
             .add_plugins(spawn::SpawnPlugin)
         ;
     }

--- a/src/block/movement.rs
+++ b/src/block/movement.rs
@@ -6,10 +6,11 @@ use crate::{
 };
 use super::{
     BLOCK_SPEED,
-    PlayerBlock,
     CollisionEvent as BlockCollisionEvent,
     Direction,
     MoveEvent,
+    CurrentBlock,
+    PlayerBlock,
 };
 use crate::wall::CollisionEvent as WallCollisionEvent;
 
@@ -37,6 +38,7 @@ pub fn falling(
 pub fn movement(
     mut read_events1: EventReader<MoveEvent>,
     mut query: Query<&mut Transform, With<PlayerBlock>>,
+    mut current_block: ResMut<CurrentBlock>,
     read_events2: EventReader<WallCollisionEvent>,
     read_events3: EventReader<BlockCollisionEvent>
 ) {
@@ -52,6 +54,12 @@ pub fn movement(
                 Direction::Bottom => transform.translation.y -= GRID_SIZE,
             }
         }
+        match direction {
+            Direction::Left   => current_block.init_pos.x -= GRID_SIZE,
+            Direction::Right  => current_block.init_pos.x += GRID_SIZE,
+            Direction::Bottom => current_block.init_pos.y -= GRID_SIZE,
+        }
+        // trace!("current_block.init_pos: {}", current_block.init_pos);
     }
 }
 

--- a/src/block/rotation.rs
+++ b/src/block/rotation.rs
@@ -1,0 +1,10 @@
+use bevy::prelude::*;
+
+pub struct RotationPlugin;
+
+impl Plugin for RotationPlugin {
+    fn build(&self, app: &mut App) {
+        app
+        ;
+    }
+}

--- a/src/block/rotation.rs
+++ b/src/block/rotation.rs
@@ -1,10 +1,20 @@
 use bevy::prelude::*;
 
-pub struct RotationPlugin;
+use super::RotationEvent;
 
-impl Plugin for RotationPlugin {
-    fn build(&self, app: &mut App) {
-        app
-        ;
-    }
+pub fn rotation(
+    mut events: EventReader<RotationEvent>,
+) {
+    if events.is_empty() { return }
+    events.clear();
+    // debug!("read RotationEvent");
 }
+
+// pub struct RotationPlugin;
+
+// impl Plugin for RotationPlugin {
+//     fn build(&self, app: &mut App) {
+//         app
+//         ;
+//     }
+// }

--- a/src/block/rotation.rs
+++ b/src/block/rotation.rs
@@ -1,13 +1,22 @@
 use bevy::prelude::*;
 
-use super::RotationEvent;
+use crate::utils::blockdata::*;
+use super::{
+    RotationEvent,
+    CurrentBlock,
+};
 
 pub fn rotation(
     mut events: EventReader<RotationEvent>,
+    mut current_block: ResMut<CurrentBlock>,
 ) {
     if events.is_empty() { return }
     events.clear();
     // debug!("read RotationEvent");
+    if current_block.id >= MAX_BLOCKDATA - 1 { current_block.id = 0 }
+    else { current_block.id += 1 }
+    // trace!("current_block.id: {}", current_block.id);
+    assert!(current_block.id < MAX_BLOCKDATA);
 }
 
 // pub struct RotationPlugin;

--- a/src/block/rotation.rs
+++ b/src/block/rotation.rs
@@ -4,11 +4,13 @@ use crate::utils::blockdata::*;
 use super::{
     RotationEvent,
     CurrentBlock,
+    PlayerBlock,
 };
 
 pub fn rotation(
     mut events: EventReader<RotationEvent>,
     mut current_block: ResMut<CurrentBlock>,
+    mut query: Query<(&PlayerBlock, &mut Transform), With<PlayerBlock>>,
 ) {
     if events.is_empty() { return }
     events.clear();
@@ -17,6 +19,15 @@ pub fn rotation(
     else { current_block.id += 1 }
     // trace!("current_block.id: {}", current_block.id);
     assert!(current_block.id < MAX_BLOCKDATA);
+
+    let block = current_block.block;
+    let blockdata_id = current_block.id;
+    let init_pos = current_block.init_pos;
+
+    for (player, mut transform) in &mut query {
+        let block_id = player.0;
+        transform.translation = block.position(init_pos, blockdata_id, block_id).extend(1.0);
+    }
 }
 
 // pub struct RotationPlugin;

--- a/src/block/spawn.rs
+++ b/src/block/spawn.rs
@@ -34,9 +34,14 @@ impl BlockType {
     // 一致した箇所をxy軸に変換して返します。
     // 例
     // BlockType::TypeI.position(2) -> INITIAL_POSITION + Vec2::new(GRID_SIZE * 1, -GRID_SIZE * 1)
-    fn position(&self, blockdata_id: usize, block_id: usize) -> Vec2 {
+    pub fn position(
+        &self,
+        init_pos: Vec2,
+        blockdata_id: usize,
+        block_id: usize,
+    ) -> Vec2 {
         let closure = |block: [[usize; 16]; 4]| {
-            let mut position = BLOCK_POSITION;
+            let mut position = init_pos;
 
             for i in 0..block[blockdata_id].len() {
                 if block_id == block[blockdata_id][i] {
@@ -46,7 +51,7 @@ impl BlockType {
                 position.x += GRID_SIZE;
                 // movement y
                 if i % 4 == 3 {
-                    position.x = BLOCK_POSITION.x;
+                    position.x = init_pos.x;
                     position.y -= GRID_SIZE;
                 }
             }

--- a/src/block/spawn.rs
+++ b/src/block/spawn.rs
@@ -71,15 +71,16 @@ impl Block {
         blockdata_id: usize,
         block_id: usize,
         block: BlockType,
-    ) -> (Self, Sprite, Transform) {
+    ) -> (Self, Sprite, Transform, PlayerBlock) {
         (
             Self,
             Sprite::from_color(block.color(), Vec2::ONE),
             Transform {
-                translation: block.position(blockdata_id, block_id).extend(1.0),
+                translation: block.position(BLOCK_POSITION, blockdata_id, block_id).extend(1.0),
                 scale: BLOCK_SIZE.extend(1.0),
                 ..Default::default()
             },
+            PlayerBlock(block_id),
         )
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -4,14 +4,16 @@ use crate::AppState;
 use crate::block::{
     MoveEvent as BlockMoveEvent,
     Direction as BlockDirection,
+    RotationEvent as BlockRotationEvent,
 };
 
 const KEY_BLOCK_LEFT_1: KeyCode = KeyCode::ArrowLeft;
 const KEY_BLOCK_LEFT_2: KeyCode = KeyCode::KeyA;
 const KEY_BLOCK_RIGHT_1: KeyCode = KeyCode::ArrowRight;
 const KEY_BLOCK_RIGHT_2: KeyCode = KeyCode::KeyD;
+const KEY_BLOCK_ROTATION: KeyCode = KeyCode::Space;
 
-pub fn block_movement(
+fn block_movement(
     mut events: EventWriter<BlockMoveEvent>,
     keyboard_input: Res<ButtonInput<KeyCode>>,
 ) {
@@ -29,6 +31,16 @@ pub fn block_movement(
     }
 }
 
+fn block_rotation(
+    mut events: EventWriter<BlockRotationEvent>,
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+) {
+    if keyboard_input.just_pressed(KEY_BLOCK_ROTATION) {
+        // debug!("send BlockRotationEvent");
+        events.send_default();
+    }
+}
+
 pub struct PlayerPlugin;
 
 impl Plugin for PlayerPlugin {
@@ -40,6 +52,10 @@ impl Plugin for PlayerPlugin {
                 crate::wall::check_for_wall,
                 crate::block::collision::check_for_collision,
                 crate::block::movement::movement,
+            ).chain().run_if(in_state(AppState::Ingame)))
+            .add_systems(Update, (
+                block_rotation,
+                crate::block::rotation::rotation,
             ).chain().run_if(in_state(AppState::Ingame)))
         ;
     }

--- a/src/utils/blockdata.rs
+++ b/src/utils/blockdata.rs
@@ -1,6 +1,7 @@
 use bevy::prelude::*;
 
 pub const BLOCK_COUNT: usize = 4;
+pub const MAX_BLOCKDATA: usize = 4;
 pub const I_BLOCK: [[usize; 16]; 4] = [
     [
         0,0,0,0,

--- a/src/wall.rs
+++ b/src/wall.rs
@@ -8,6 +8,7 @@ use crate::block::{
     MoveEvent as BlockMoveEvent,
     Direction as BlockDirection,
     SpawnEvent,
+    CurrentBlock,
     PlayerBlock,
 };
 
@@ -143,10 +144,13 @@ fn bottom_hit(
     mut read_events: EventReader<BottomHitEvent>,
     mut write_events: EventWriter<SpawnEvent>,
     mut commands: Commands,
+    mut current_block: ResMut<CurrentBlock>,
     query: Query<Entity, With<PlayerBlock>>,
 ) {
     if read_events.is_empty() { return }
     read_events.clear();
+    // debug!("reset current block");
+    *current_block = CurrentBlock::reset();
     // debug!("remove PlayerBlock components");
     for entity in &query { commands.entity(entity).remove::<PlayerBlock>(); }
     // debug!("send spawn event");


### PR DESCRIPTION
# Issue:
- #25
- #36

# Pulls:
- #38

## Changes
ブロックに回転処理を追加しました。
スペースキーを押すことでブロックを回転させることができます。

## Code changes
- `src/block/rotation.rs`を作成
- `RotationEvent`を`src/block/mod.rs`に作成
- `PlayerBlock`にID`usize`を追加
- `CurrentBlock`リソースを`src/block/mod.rs`に作成
    - `rand`クレートを追加
    - `BlockType`を乱数を追加

