### PR TITLE
fix: :zap: fix key move event

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -7,6 +7,7 @@ use crate::{
     HardDropEvent,
     Direction,
     FallingTimer,
+    MoveLeftTimer,
     MoveBottomTimer,
     AppState,
 };
@@ -32,10 +33,45 @@ fn move_event(
     };
     for key in keyboard_input.get_just_pressed() {
         match *key {
-            KEY_BLOCK_LEFT_1   | KEY_BLOCK_LEFT_2   => closure(Direction::Left),
             KEY_BLOCK_RIGHT_1  | KEY_BLOCK_RIGHT_2  => closure(Direction::Right),
             _ => {},
         }
+    }
+}
+
+fn key_block_moveleft(
+    mut events: EventWriter<MoveEvent>,
+    mut moveleft_timer: ResMut<MoveLeftTimer>,
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    time: Res<Time>,
+) {
+    info_once!("key_block_moveleft");
+
+    let block_left_keys = [KEY_BLOCK_LEFT_1, KEY_BLOCK_LEFT_2];
+
+    // ブロック左移動キー入力時
+    if keyboard_input.any_just_pressed(block_left_keys) {
+        // ブロック移動イベントを発火
+        events.send(MoveEvent(Direction::Left));
+    }
+
+    // ブロック左移動キー長押し時
+    if keyboard_input.any_pressed(block_left_keys) {
+        // ブロック左移動タイマーを進める
+        moveleft_timer.0.tick(time.delta());
+        // タイマーが切れたら
+        if moveleft_timer.0.elapsed_secs() > BLOCK_MOVE_SPEED {
+            // ブロック左移動タイマーをリセット
+            moveleft_timer.0.reset();
+            // ブロック移動イベントを発火
+            events.send(MoveEvent(Direction::Left));
+        }
+    }
+
+    // ブロック左移動キーを離した時
+    if keyboard_input.any_just_released(block_left_keys) {
+        // ブロック下移動タイマーをリセット
+        moveleft_timer.0.reset();
     }
 }
 
@@ -121,6 +157,7 @@ impl Plugin for KeyPlugin {
         app
             .add_systems(Update, (
                 move_event,
+                key_block_moveleft,
                 key_block_movebottom,
                 rotation_event,
                 harddrop_event,

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,9 @@ enum Direction {
 struct FallingTimer(Timer);
 
 #[derive(Resource, Deref, DerefMut)]
+struct MoveLeftTimer(Stopwatch);
+
+#[derive(Resource, Deref, DerefMut)]
 struct MoveBottomTimer(Stopwatch);
 
 #[derive(States, Default, Debug, Clone, PartialEq, Eq, Hash)]
@@ -96,6 +99,7 @@ fn main() {
         .add_event::<SpawnEvent>()
         .add_event::<FixEvent>()
         .insert_resource(FallingTimer::new())
+        .insert_resource(MoveLeftTimer(Stopwatch::new()))
         .insert_resource(MoveBottomTimer(Stopwatch::new()))
         .add_plugins(field::FieldPlugin)
         .add_plugins(key::KeyPlugin)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use bevy::{
     prelude::*,
     log::LogPlugin,
+    time::Stopwatch,
 };
 
 mod block;
@@ -22,7 +23,8 @@ const PATH_IMAGE_RETRY: &str = "images/rotate-left-dark.png";
 const PATH_SOUND_BGM: &str = "bevy-tetris/bgm.ogg";
 
 const GRID_SIZE: f32 = 20.0;
-const BLOCK_SPEED: f32 = 0.5;
+const BLOCK_FALL_SPEED: f32 = 0.5;
+const BLOCK_MOVE_SPEED: f32 = 0.25;
 const FIELD_SIZE: Vec2 = Vec2::new(10.0 * GRID_SIZE, 20.0 * GRID_SIZE);
 const FIELD_POSITION: Vec3 = Vec3::new(0.0, 0.0, -10.0);
 
@@ -51,6 +53,9 @@ enum Direction {
 #[derive(Resource, Deref, DerefMut)]
 struct FallingTimer(Timer);
 
+#[derive(Resource, Deref, DerefMut)]
+struct MoveBottomTimer(Stopwatch);
+
 #[derive(States, Default, Debug, Clone, PartialEq, Eq, Hash)]
 enum AppState {
     #[default]
@@ -61,11 +66,7 @@ enum AppState {
 
 impl FallingTimer {
     fn new() -> Self {
-        Self(Timer::from_seconds(BLOCK_SPEED, TimerMode::Repeating))
-    }
-
-    fn update_timer(seconds: f32) -> Timer {
-        Timer::from_seconds(seconds, TimerMode::Repeating)
+        Self(Timer::from_seconds(BLOCK_FALL_SPEED, TimerMode::Repeating))
     }
 }
 
@@ -95,6 +96,7 @@ fn main() {
         .add_event::<SpawnEvent>()
         .add_event::<FixEvent>()
         .insert_resource(FallingTimer::new())
+        .insert_resource(MoveBottomTimer(Stopwatch::new()))
         .add_plugins(field::FieldPlugin)
         .add_plugins(key::KeyPlugin)
         .add_plugins(block::BlockPlugin)

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,9 @@ struct FallingTimer(Timer);
 struct MoveLeftTimer(Stopwatch);
 
 #[derive(Resource, Deref, DerefMut)]
+struct MoveRightTimer(Stopwatch);
+
+#[derive(Resource, Deref, DerefMut)]
 struct MoveBottomTimer(Stopwatch);
 
 #[derive(States, Default, Debug, Clone, PartialEq, Eq, Hash)]
@@ -100,6 +103,7 @@ fn main() {
         .add_event::<FixEvent>()
         .insert_resource(FallingTimer::new())
         .insert_resource(MoveLeftTimer(Stopwatch::new()))
+        .insert_resource(MoveRightTimer(Stopwatch::new()))
         .insert_resource(MoveBottomTimer(Stopwatch::new()))
         .add_plugins(field::FieldPlugin)
         .add_plugins(key::KeyPlugin)


### PR DESCRIPTION
# Issue
- #78

## Changes
ブロック移動キーの長押しに対応しました。
キーを押し続けても移動し続けることができます。
`MoveLeftTimer, MoveRightTimer, MoveBottomTimer`リソースを追加しました。
`key_block_moveleft, key_block_moveright, key_block_movebottom`を追加しました。


### Commits